### PR TITLE
add defaultMonth prop to date pickers

### DIFF
--- a/components/ui/date-picker-jalali.tsx
+++ b/components/ui/date-picker-jalali.tsx
@@ -39,6 +39,7 @@ export function DatePickerJalali() {
           mode="single"
           selected={date}
           onSelect={setDate}
+          defaultMonth={date}
           autoFocus
         />
       </PopoverContent>

--- a/components/ui/multiple-picker-jalali.tsx
+++ b/components/ui/multiple-picker-jalali.tsx
@@ -43,6 +43,7 @@ export function MultiplePickerJalali() {
           mode="multiple"
           selected={dateList}
           onSelect={setDateList}
+          defaultMonth={dateList[0]}
           required={true}
           max={3}
         />

--- a/components/ui/range-picker-jalali.tsx
+++ b/components/ui/range-picker-jalali.tsx
@@ -43,6 +43,7 @@ export function RangePickerJalali() {
           mode="range"
           selected={dateRange}
           onSelect={setDateRange}
+          defaultMonth={dateRange?.from}
         />
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
Hi Mahdi,

Thanks for your awesome Jalali calendar—it's been really helpful!

I thought it’d be a nice enhancement to add a defaultMonth prop to the DatePickers. This will allow users to see their selected month by default, improving the overall UX.

Let me know what you think! No worries if it doesn’t fit, feel free to reject the PR.

